### PR TITLE
Handle 32-bit Python on 64-bit Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+.idea/misc.xml
+*.xml
+*.iml

--- a/WindowsRegistry.py
+++ b/WindowsRegistry.py
@@ -60,8 +60,6 @@ class WindowsRegistry:
         while not_opened and i<len(rights)-1:
             try:
                 if platform.machine().endswith('64') and platform.architecture()[0] == '32bit':
-                    print('yes')
-                    print(rights[i])
                     self.key = wreg.OpenKey(wreg.HKEY_LOCAL_MACHINE, self.keyname, 0, rights[i] | wreg.KEY_WOW64_64KEY)
                 else:
                     self.key = wreg.OpenKey(wreg.HKEY_LOCAL_MACHINE, self.keyname,0, rights[i])

--- a/WindowsRegistry.py
+++ b/WindowsRegistry.py
@@ -1,6 +1,7 @@
 import sys
 import _winreg as wreg
 import cPickle as pickle
+import platform
 
 class WindowsRegistry:
     """ A class to simplify read/write access to the Windows Registry """
@@ -58,7 +59,12 @@ class WindowsRegistry:
         i=0
         while not_opened and i<len(rights)-1:
             try:
-                self.key = wreg.OpenKey(wreg.HKEY_LOCAL_MACHINE, self.keyname,0, rights[i])
+                if platform.machine().endswith('64') and platform.architecture()[0] == '32bit':
+                    print('yes')
+                    print(rights[i])
+                    self.key = wreg.OpenKey(wreg.HKEY_LOCAL_MACHINE, self.keyname, 0, rights[i] | wreg.KEY_WOW64_64KEY)
+                else:
+                    self.key = wreg.OpenKey(wreg.HKEY_LOCAL_MACHINE, self.keyname,0, rights[i])
                 not_opened = False
                 self.right = rights[i]
                 #print "rights = %05x" % rights[i]

--- a/vncpasswd.py
+++ b/vncpasswd.py
@@ -125,7 +125,7 @@ def main():
     if ( args.filename == None and args.passwd == None and (args.registry == False or not platform.system().startswith('Windows')) ):
         parser.error('Error: No password file or password passed\n')
     if ( args.registry and args.decrypt and platform.system().startswith('Windows')):
-        reg = wreg.WindowsRegistry("RealVNC", "vncserver")
+        reg = get_realvnc_key()
         ( args.passwd, key_type) = reg.getval("Password")
     elif not platform.system().startswith('Windows'):
 	print 'Cannot read from Windows Registry on a %s system' % platform.system()
@@ -159,7 +159,7 @@ def main():
     if ( args.filename != None and not args.decrypt ):
         do_file_out(args.filename, crypted, args.hex)
     if ( args.registry and not args.decrypt and platform.system().startswith('Windows')):
-        reg = wreg.WindowsRegistry("RealVNC", "vncserver")
+        reg = get_realvnc_key()
         reg.setval('Password', crypted, wreg.WindowsRegistry.REG_BINARY)
     elif not platform.system().startswith('Windows'):
 	print 'Cannot write to Windows Registry on a %s system' % platform.system()
@@ -167,6 +167,23 @@ def main():
     prefix = ('En','De')[args.decrypt == True]
     print "%scrypted Bin Pass= '%s'" % ( prefix, crypted )
     print "%scrypted Hex Pass= '%s'" % ( prefix, crypted.encode('hex') )
+
+
+def get_realvnc_key():
+    reg = None
+
+    for k in ['vncserver', 'WinVNC4',]:
+        try:
+            reg = wreg.WindowsRegistry('RealVNC', k)
+            break
+        except WindowsError as e:
+            if 'The system cannot find the file specified' in str(e):
+                pass
+            else:
+                raise e
+
+    return reg
+
 
 if __name__ == '__main__':
 	main()

--- a/vncpasswd.py
+++ b/vncpasswd.py
@@ -125,7 +125,7 @@ def main():
     if ( args.filename == None and args.passwd == None and (args.registry == False or not platform.system().startswith('Windows')) ):
         parser.error('Error: No password file or password passed\n')
     if ( args.registry and args.decrypt and platform.system().startswith('Windows')):
-        reg = wreg.WindowsRegistry("RealVNC", "WinVNC4")
+        reg = wreg.WindowsRegistry("RealVNC", "vncserver")
         ( args.passwd, key_type) = reg.getval("Password")
     elif not platform.system().startswith('Windows'):
 	print 'Cannot read from Windows Registry on a %s system' % platform.system()
@@ -159,7 +159,7 @@ def main():
     if ( args.filename != None and not args.decrypt ):
         do_file_out(args.filename, crypted, args.hex)
     if ( args.registry and not args.decrypt and platform.system().startswith('Windows')):
-        reg = wreg.WindowsRegistry("RealVNC", "WinVNC4")
+        reg = wreg.WindowsRegistry("RealVNC", "vncserver")
         reg.setval('Password', crypted, wreg.WindowsRegistry.REG_BINARY)
     elif not platform.system().startswith('Windows'):
 	print 'Cannot write to Windows Registry on a %s system' % platform.system()


### PR DESCRIPTION
Also, reg path changed from WinVNC4 to vncserver. This will cover the following issue:
https://github.com/trinitronx/vncpasswd.py/issues/4