### PR TITLE
Fix VERSION file newline bug on Linux when creating Python sdist via: `make setup`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ except ImportError:
         readme = f.read()
 
 with open(VERSION_TXT_PATH, 'r') as f:
-        version = f.read()
+        version = f.read().rstrip()
 
 setup(
     name='vncpasswd.py',


### PR DESCRIPTION
Output file was ending up with string `'$'\n''` suffixed to `$VERSION`.  Cause was that we read in `VERSION` file contents directly into `setup(version=`, which included the newline.

Fix was: use `.rstrip()` method to remove the newline!