### PR TITLE
fix(non-windows): Only print registry warning on non-Windows platform…

### DIFF
--- a/vncpasswd.py
+++ b/vncpasswd.py
@@ -127,7 +127,7 @@ def main():
     if ( args.registry and args.decrypt and platform.system().startswith('Windows')):
         reg = get_realvnc_key()
         ( args.passwd, key_type) = reg.getval("Password")
-    elif not platform.system().startswith('Windows'):
+    elif ( args.registry and not platform.system().startswith('Windows') ):
         print 'Cannot read from Windows Registry on a %s system' % platform.system()
     if ( args.passwd != None and args.hex ):
         args.passwd = unhex(args.passwd)
@@ -161,7 +161,7 @@ def main():
     if ( args.registry and not args.decrypt and platform.system().startswith('Windows')):
         reg = get_realvnc_key()
         reg.setval('Password', crypted, wreg.WindowsRegistry.REG_BINARY)
-    elif not platform.system().startswith('Windows'):
+    elif ( args.registry and not platform.system().startswith('Windows') ):
         print 'Cannot write to Windows Registry on a %s system' % platform.system()
 
     prefix = ('En','De')[args.decrypt == True]


### PR DESCRIPTION
…s when -R flag is requested (fixes #18)