### PR TITLE
fix(non-windows): Fixes #23 - Handle `_key_type` check properly on non-windows platforms

### DIFF
--- a/vncpasswd.py
+++ b/vncpasswd.py
@@ -137,7 +137,13 @@ def main():
     if (args.test):
         run_tests()
 
+    # Handle _key_type checks on all platforms
     _key_type = None
+    if platform.system().startswith('Windows'):
+        _reg_sz_type = wreg.WindowsRegistry.REG_SZ
+    else:
+        _reg_sz_type = 1
+
     if ( args.filename == None and args.passwd == None and (args.registry == False or not platform.system().startswith('Windows')) ):
         parser.error('Error: No password file or password passed\n')
     if ( args.registry and args.decrypt and platform.system().startswith('Windows')):
@@ -150,7 +156,7 @@ def main():
             eprint('Are you sure that you have RealVNC / WinVNC4 installed?')
     elif ( args.registry and not platform.system().startswith('Windows') ):
         eprint('Cannot read from Windows Registry on a %s system' % platform.system())
-    if ( args.passwd != None and (args.hex or _key_type == wreg.WindowsRegistry.REG_SZ)):
+    if ( args.passwd != None and (args.hex or _key_type == _reg_sz_type)):
         args.passwd = unhex(args.passwd)
     if ( args.filename != None and args.decrypt ):
         args.passwd = do_file_in(args.filename, args.hex)


### PR DESCRIPTION
Closes #23 

Error was:

    Traceback (most recent call last):
      File "./vncpasswd.py", line 224, in <module>
        main()
      File "./vncpasswd.py", line 153, in main
        if ( args.passwd != None and (args.hex or _key_type == wreg.WindowsRegistry.REG_SZ)):
    NameError: global name 'wreg' is not defined